### PR TITLE
Add opt-in toggle for NES sprite selector overrides

### DIFF
--- a/src/components/CharacterSelector.svelte
+++ b/src/components/CharacterSelector.svelte
@@ -10,15 +10,21 @@
     let samusDialog;
     let linkAssetIndex = 0;
     let samusAssetIndex = 0;
+    let spriteOverrideEnabled = false;
     let mounted = false;
 
     // Sync store whenever `selected` changes
-    $: assetState.update(state => typeof(linkAssetIndex) === 'number' ? ({ ...state, linkAsset: LinkAssets[linkAssetIndex] }) : state);
-    $: assetState.update(state => typeof(samusAssetIndex) === 'number' ? ({ ...state, samusAsset: SamusAssets[samusAssetIndex] }) : state);
+    $: assetState.update(state => ({
+        ...state,
+        spriteOverrideEnabled,
+        linkAsset: typeof(linkAssetIndex) === 'number' ? LinkAssets[linkAssetIndex] : undefined,
+        samusAsset: typeof(samusAssetIndex) === 'number' ? SamusAssets[samusAssetIndex] : undefined
+    }));
 
     onMount(() => {
         const link  = localStorage.getItem('linkAssetIndex');
         const samus = localStorage.getItem('samusAssetIndex');
+        const overrideEnabled = localStorage.getItem('spriteOverrideEnabled');
 
         if (link !== null) {
             linkAssetIndex = +link;
@@ -28,12 +34,17 @@
             samusAssetIndex = +samus;
         }
 
+        if (overrideEnabled !== null) {
+            spriteOverrideEnabled = overrideEnabled === 'true';
+        }
+
         mounted = true;
     });
 
     $: if (mounted) {
         localStorage.setItem('linkAssetIndex', linkAssetIndex);
         localStorage.setItem('samusAssetIndex', samusAssetIndex);
+        localStorage.setItem('spriteOverrideEnabled', String(spriteOverrideEnabled));
     }
 
     //  Generate data assets above with the following scripts:
@@ -46,11 +57,16 @@
 
 <h2>Customizations</h2>
 
-<section class="customization">
+<label class="spriteOverrideToggle">
+    <input type="checkbox" bind:checked={spriteOverrideEnabled} />
+    Enable NES sprite selector override
+</label>
+
+<section class="customization" class:disabled={!spriteOverrideEnabled}>
     <div>
         <label for="zeldaButton">Zelda 1, play as</label>
         {#if mounted}
-            <button id="zeldaButton" class="assetPreview image-option preview" on:click|preventDefault={linkDialog.openDialog}>
+            <button id="zeldaButton" class="assetPreview image-option preview" on:click|preventDefault={linkDialog.openDialog} disabled={!spriteOverrideEnabled}>
                 {#if typeof(linkAssetIndex) === 'number'}
                     <NesChrRenderer
                         b64String={LinkAssets[linkAssetIndex].writes[2].base64}
@@ -68,7 +84,7 @@
     <div>
         <label for="samusButton">Metroid 1, play as</label>
         {#if mounted}
-            <button id="samusButton" class="assetPreview image-option preview" on:click|preventDefault={samusDialog.openDialog}>
+            <button id="samusButton" class="assetPreview image-option preview" on:click|preventDefault={samusDialog.openDialog} disabled={!spriteOverrideEnabled}>
                 {#if typeof(samusAssetIndex) === 'number'}
                     <NesChrRenderer
                         assetType="samus"
@@ -191,5 +207,21 @@
 
     :global(.image-option:hover svg) {
         transform: scale(1.1);
+    }
+
+
+    .spriteOverrideToggle {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+        justify-content: center;
+    }
+
+    .customization.disabled {
+        opacity: 0.6;
+    }
+
+    button.preview:disabled {
+        cursor: not-allowed;
     }
 </style>

--- a/src/components/CharacterSelector.svelte
+++ b/src/components/CharacterSelector.svelte
@@ -57,9 +57,9 @@
 
 <h2>Customizations</h2>
 
-<label class="spriteOverrideToggle">
-    <input type="checkbox" bind:checked={spriteOverrideEnabled} />
-    Enable NES sprite selector override
+<label class="spriteOverrideToggle" for="spriteOverrideToggle">
+    <input id="spriteOverrideToggle" type="checkbox" bind:checked={spriteOverrideEnabled} />
+    <span>Override NES sprites</span>
 </label>
 
 <section class="customization" class:disabled={!spriteOverrideEnabled}>
@@ -211,14 +211,68 @@
 
 
     .spriteOverrideToggle {
-        display: flex;
+        display: inline-flex;
         align-items: center;
-        gap: 0.5rem;
         justify-content: center;
+        gap: 0.65rem;
+
+        cursor: pointer;
+        border: 2px solid #ddd;
+        background: #eee;
+        padding: 10px 14px;
+        border-radius: 8px;
+        transition: var(--transition-time);
+        margin: 0 auto;
+    }
+
+    .spriteOverrideToggle:hover,
+    .spriteOverrideToggle:focus-within {
+        background: #ddd;
+        border-color: #ccc;
+    }
+
+    .spriteOverrideToggle input[type="checkbox"] {
+        appearance: none;
+        width: 1.1rem;
+        height: 1.1rem;
+        margin: 0;
+        border: 2px solid #999;
+        border-radius: 0.25rem;
+        background: white;
+        display: grid;
+        place-content: center;
+        transition: var(--transition-time);
+    }
+
+    .spriteOverrideToggle input[type="checkbox"]::before {
+        content: "";
+        width: 0.5rem;
+        height: 0.5rem;
+        transform: scale(0);
+        transition: transform var(--transition-time) ease-in-out;
+        box-shadow: inset 1em 1em rgb(0, 123, 255);
+        border-radius: 0.1rem;
+    }
+
+    .spriteOverrideToggle input[type="checkbox"]:checked {
+        border-color: rgb(0, 123, 255);
+    }
+
+    .spriteOverrideToggle input[type="checkbox"]:checked::before {
+        transform: scale(1);
+    }
+
+    .spriteOverrideToggle span {
+        font-size: 1rem;
     }
 
     .customization.disabled {
         opacity: 0.6;
+        transition: opacity var(--transition-time);
+    }
+
+    .customization {
+        transition: opacity var(--transition-time);
     }
 
     button.preview:disabled {

--- a/src/lib/selected-sprites-store.js
+++ b/src/lib/selected-sprites-store.js
@@ -14,6 +14,7 @@ const base64ToUint8Array = (base64) => {
 }
 
 export const assetState = writable({
+  spriteOverrideEnabled: false,
   linkAsset: undefined,
   samusAsset: undefined,
   base64ToUint8Array

--- a/src/routes/[[patch]]/+page.svelte
+++ b/src/routes/[[patch]]/+page.svelte
@@ -154,6 +154,10 @@
                     romFile.setName(outFileName);
                 },
                 onpatch: function (patchedRomFile) {
+                    if (!$assetState.spriteOverrideEnabled) {
+                        return;
+                    }
+
                     let selLink  = $assetState.linkAsset;
                     let selSamus = $assetState.samusAsset;
                     if(selLink && selLink?.name && (selLink?.name !== 'Link')) {


### PR DESCRIPTION
### Motivation
- Make NES sprite selector behavior opt-in so users don't accidentally overwrite ROM sprites. 
- Keep the override disabled by default to preserve current behavior unless the user explicitly enables it.

### Description
- Added a `spriteOverrideEnabled` flag to the shared asset state in `src/lib/selected-sprites-store.js` with a default of `false`.
- Added a checkbox and persistence in `src/components/CharacterSelector.svelte` labeled `Enable NES sprite selector override`, and disabled the Zelda/Samus selector buttons when the toggle is off.
- Updated the patch application logic in `src/routes/[[patch]]/+page.svelte` to skip writing NES sprite data unless `spriteOverrideEnabled` is true.
- Added small CSS to visually indicate the disabled customization state and to make the toggle UI consistent.

### Testing
- Ran `npm run build`, which completed successfully (production build artifacts were generated).
- Ran `npm run check`, which failed due to pre-existing repository-wide type/check issues that are unrelated to this change (errors reported by `svelte-check`).
- Started the dev server and verified the new toggle appears and the UI disables the selectors when off by loading the app and capturing a screenshot from the running dev instance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994d01ba8788329aaf692ac10432b63)